### PR TITLE
User configuration setup.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,13 +21,14 @@ options:
 ${OBJ}: config.h config.mk
 
 config.h:
-	cp config.def.h $@
+	mkdir -p /etc/xdg/towm
+	cp config.def.h /etc/xdg/towm/towm.default.h
 
 towm: ${OBJ}
 	${CC} -o $@ ${OBJ} ${LDFLAGS}
 
 clean:
-	rm -f towm ${OBJ} towm-${VERSION}.tar.gz config.h
+	rm -f towm ${OBJ} towm-${VERSION}.tar.gz
 
 dist: clean
 	mkdir -p towm-${VERSION}
@@ -36,6 +37,12 @@ dist: clean
 	tar -cf towm-${VERSION}.tar towm-${VERSION}
 	gzip towm-${VERSION}.tar
 	rm -rf towm-${VERSION}
+
+setup:
+	rm -fr ${DESTDIR}${PREFIX}/share/towm
+	mkdir -p ${DESTDIR}${PREFIX}/share/towm
+	cp -R LICENSE Makefile README config.def.h config.mk\
+		towm.1 drw.h util.h ${SRC} transient.c ${DESTDIR}${PREFIX}/share/towm
 
 install: all
 	mkdir -p ${DESTDIR}${PREFIX}/bin
@@ -49,4 +56,4 @@ uninstall:
 	rm -f ${DESTDIR}${PREFIX}/bin/towm\
 		${DESTDIR}${MANPREFIX}/man1/towm.1
 
-.PHONY: all options clean dist install uninstall
+.PHONY: all options clean dist setup install uninstall

--- a/config.mk
+++ b/config.mk
@@ -9,6 +9,8 @@ MANPREFIX = ${PREFIX}/share/man
 
 X11INC = /usr/X11R6/include
 X11LIB = /usr/X11R6/lib
+TOWMXDG = /etc/xdg/towm
+TOWMUSR = /home/${SUDO_USER}/.config/towm
 
 # Xinerama, comment if you don't want it
 XINERAMALIBS  = -lXinerama
@@ -22,7 +24,7 @@ FREETYPEINC = /usr/include/freetype2
 #MANPREFIX = ${PREFIX}/man
 
 # includes and libs
-INCS = -I${X11INC} -I${FREETYPEINC}
+INCS = -I${X11INC} -I${FREETYPEINC} -I${TOWMUSR} -I${TOWMXDG}
 LIBS = -L${X11LIB} -lX11 ${XINERAMALIBS} ${FREETYPELIBS}
 
 # flags

--- a/towm.c
+++ b/towm.c
@@ -26,6 +26,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <unistd.h>
 #include <sys/types.h>
@@ -269,7 +270,11 @@ static Monitor *mons, *selmon;
 static Window root, wmcheckwin;
 
 /* configuration, allows nested code to access above variables */
-#include "config.h"
+#if __has_include("towm.h")
+#include "towm.h"
+#else
+#include "towm.default.h"
+#endif
 
 /* compile-time check if all tags fit into an unsigned int bit array. */
 struct NumTags { char limitexceeded[LENGTH(tags) > 31 ? -1 : 1]; };
@@ -2167,10 +2172,16 @@ zoom(const Arg *arg)
 int
 main(int argc, char *argv[])
 {
-	if (argc == 2 && !strcmp("-v", argv[1]))
+	if (argc == 2 && !strcmp("-v", argv[1])) {
 		die("towm-"VERSION);
+	}
+	else if (argc == 2 && !strcmp("-c", argv[1])) {
+		system("cd /usr/local/share/towm && sudo make && sudo make install");
+		die("towm compiled successfully.");
+	}
 	else if (argc != 1)
-		die("usage: towm [-v]");
+		die("usage: towm [-v] [-c]");
+	
 	if (!setlocale(LC_CTYPE, "") || !XSupportsLocale())
 		fputs("warning: no locale support\n", stderr);
 	if (!(dpy = XOpenDisplay(NULL)))


### PR DESCRIPTION
This is for towm v0.2.

In this commit, major changes have been made to how to install and configure towm, these include:

The order of install commands has been updated to this:

- sudo make
- sudo make setup
- sudo make install

the 'setup' was added to install the source code for towm in '/usr/local/share/towm' to accommodate for the config changes.

These changes include:

- default config is here: /etc/xdg/towm/towm.default.h
- user config is here: ~/.config/towm/towm.h

These means that towm will use the config file in the xdg folder if the user config does not exist, otherwise use the user config.

Now there is an in built command, for compiling town, this being 'towm -c'.

this will only work if 'sudo make setup' was ran.